### PR TITLE
Implement v12 of python-telegram-bot api and settings command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,8 @@ allow_failures:
 # command to install dependencies
 install:
   - pip install -r requirements.txt
-  - pip install codecov
   - export PYTHONPATH=$PYTHONPATH:$(pwd)
 # command to run tests
 script:
   - python3 ChaturbateBot.py -h
-after_success:
-  - codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,11 @@ allow_failures:
 # command to install dependencies
 install:
   - pip install -r requirements.txt
+  - pip install codecov
   - export PYTHONPATH=$PYTHONPATH:$(pwd)
 # command to run tests
 script:
   - python3 ChaturbateBot.py -h
+after_success:
+  - codecov
 

--- a/ChaturbateBot.py
+++ b/ChaturbateBot.py
@@ -54,7 +54,7 @@ def send_message(chatid: str, messaggio: str, bot: updater.bot, html: bool = Fal
 
     disable_webpage_preview = not Preferences.get_user_link_preview_preference(chatid)  # the setting is opposite of preference
 
-    notification = not Preferences.get_user_notifications_preference(chatid) # the setting is opposite of preference
+    notification = not Preferences.get_user_notifications_sound_preference(chatid) # the setting is opposite of preference
 
     try:
         bot.send_chat_action(chat_id=chatid, action="typing")
@@ -285,7 +285,7 @@ def stream_image(update, CallbackContext) -> None:
 #region settings
 
 settings_menu_keyboard = [[InlineKeyboardButton("Link preview", callback_data='link_preview_menu'),
-                 InlineKeyboardButton("Notifications", callback_data='notifications_menu_menu')]]
+                 InlineKeyboardButton("Notifications sound", callback_data='notifications_sound_menu')]]
 
 def settings(update, CallbackContext):
     global bot
@@ -295,8 +295,8 @@ def settings(update, CallbackContext):
     message_markup = InlineKeyboardMarkup(settings_menu_keyboard)
 
     Link_preview_setting = Preferences.get_user_link_preview_preference(chatid)
-    Notification_setting = Preferences.get_user_notifications_preference(chatid)
-    settings_message= f"Here are your settings:\nLink preview: <b>{Link_preview_setting}</b>\nNotifications: <b>{Notification_setting}</b>"
+    Notifications_sound_setting = Preferences.get_user_notifications_sound_preference(chatid)
+    settings_message= f"Here are your settings:\nLink preview: <b>{Link_preview_setting}</b>\nNotifications: <b>{Notifications_sound_setting}</b>"
 
     if update.callback_query:
         update.callback_query.edit_message_text(text=settings_message,reply_markup=message_markup,parse_mode=telegram.ParseMode.HTML)
@@ -313,7 +313,7 @@ def link_preview_callback(update, CallbackContext):
     markup = InlineKeyboardMarkup(keyboard)
 
 
-    query.edit_message_text(text=f"Select an option:",reply_markup=markup)
+    query.edit_message_text(text=f"Select an option",reply_markup=markup)
 
 
 def link_preview_callback_update_value(update, CallbackContext):
@@ -333,38 +333,33 @@ def link_preview_callback_update_value(update, CallbackContext):
     query.edit_message_text(text=f"The link preview preference has been set to <b>{setting}</b>",reply_markup=keyboard,parse_mode=telegram.ParseMode.HTML)
 
 
-def notifications_callback(update, CallbackContext):
+def notifications_sound_callback(update, CallbackContext):
     query = update.callback_query
 
-    keyboard = [[InlineKeyboardButton("True", callback_data='notifications_callback_True'),
-                 InlineKeyboardButton("False", callback_data='notifications_callback_False'),
-                 InlineKeyboardButton("Back", callback_data='notifications_menu')]]
+    keyboard = [[InlineKeyboardButton("True", callback_data='notifications_sound_callback_True'),
+                 InlineKeyboardButton("False", callback_data='notifications_sound_callback_False'),
+                 InlineKeyboardButton("Back", callback_data='settings_menu')]]
 
     markup = InlineKeyboardMarkup(keyboard)
 
 
-    query.edit_message_text(text=f"Select an option:",reply_markup=markup)
+    query.edit_message_text(text=f"Select an option",reply_markup=markup)
 
-def notifications_callback_update_value(update, CallbackContext):
+def notifications_sound_callback_update_value(update, CallbackContext):
     query = update.callback_query
     chatid=query.message.chat.id
 
     keyboard = [[InlineKeyboardButton("Settings", callback_data='settings_menu')]]
     keyboard = InlineKeyboardMarkup(keyboard)
 
-    if query.data=="notifications_callback_True":
+    if query.data=="notifications_sound_callback_True":
         setting=True
     else:
         setting=False
 
-    Preferences.update_notifications_preference(chatid,setting)
-    logging.info(f'{chatid} has set notifications to {setting}')
-    query.edit_message_text(text=f"The notifications preference has been set to <b>{setting}</b>",reply_markup=keyboard,parse_mode=telegram.ParseMode.HTML)
-
-
-
-
-
+    Preferences.update_notifications_sound_preference(chatid,setting)
+    logging.info(f'{chatid} has set notifications sound to {setting}')
+    query.edit_message_text(text=f"The notifications sound preference has been set to <b>{setting}</b>",reply_markup=keyboard,parse_mode=telegram.ParseMode.HTML)
 
 #endregion
 
@@ -600,15 +595,12 @@ dispatcher.add_handler(CallbackQueryHandler(link_preview_callback, pattern='link
 
 dispatcher.add_handler(CallbackQueryHandler(link_preview_callback_update_value, pattern='link_preview_callback_True|link_preview_callback_False'))
 
-dispatcher.add_handler(CallbackQueryHandler(notifications_callback, pattern='notifications_menu'))
+dispatcher.add_handler(CallbackQueryHandler(notifications_sound_callback, pattern='notifications_sound_menu'))
 
-dispatcher.add_handler(CallbackQueryHandler(notifications_callback_update_value, pattern='notifications_callback_True|notifications_callback_False'))
+dispatcher.add_handler(CallbackQueryHandler(notifications_sound_callback_update_value, pattern='notifications_sound_callback_True|notifications_sound_callback_False'))
 
 dispatcher.add_handler(CallbackQueryHandler(settings, pattern='settings_menu'))
 
-'''
-dispatcher.add_handler(CallbackQueryHandler(button2,pattern='disable_notifications_menu'))
-'''
 
 dispatcher.add_handler(CommandHandler('authorize_admin', authorize_admin))
 
@@ -630,7 +622,7 @@ Utils.exec_query("""CREATE TABLE IF NOT EXISTS ADMIN (
 Utils.exec_query('''CREATE TABLE IF NOT EXISTS "PREFERENCES" (
 	"CHAT_ID"	CHAR(100) UNIQUE,
 	"LINK_PREVIEW"	INTEGER DEFAULT 1,
-	"NOTIFICATIONS"	INTEGER DEFAULT 1,
+	"NOTIFICATIONS_SOUND"	INTEGER DEFAULT 1,
 	PRIMARY KEY("CHAT_ID")
 )''')
 

--- a/ChaturbateBot.py
+++ b/ChaturbateBot.py
@@ -39,14 +39,15 @@ logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s
 
 
 
-def send_message(chatid: str, messaggio: str, bot: updater.bot, html: bool = False) -> None:
+def send_message(chatid: str, messaggio: str, bot: updater.bot, html: bool = False, reply__markup=None) -> None:
     """
-    Sends a message to a telegram user
+    Sends a message to a telegram user and sends "typing" action
 
-    :param str chatid: The chatid of the user who will receive the message
-    :param str messaggio: The message who the user will receive
+    :param reply__markup: Parse reply_markup
+    :param chatid: The chatid of the user who will receive the message
+    :param messaggio: The message who the user will receive
     :param bot: telegram bot instance
-    :param bool html: Enable html markdown parsing in the message
+    :param html: Enable html markdown parsing in the message
     """
 
     disable_webpage_preview = not Preferences.get_user_link_preview_preference(
@@ -54,9 +55,15 @@ def send_message(chatid: str, messaggio: str, bot: updater.bot, html: bool = Fal
 
     try:
         bot.send_chat_action(chat_id=chatid, action="typing")
-        if html:
+        if html and reply_markup!=None:
+            bot.send_message(chat_id=chatid, text=messaggio,
+                             parse_mode=telegram.ParseMode.HTML, disable_web_page_preview=disable_webpage_preview,reply_markup=reply__markup)
+        elif html:
             bot.send_message(chat_id=chatid, text=messaggio,
                              parse_mode=telegram.ParseMode.HTML, disable_web_page_preview=disable_webpage_preview)
+        elif reply__markup!=None:
+            bot.send_message(chat_id=chatid, text=messaggio,disable_web_page_preview=disable_webpage_preview,
+                             reply_markup=reply__markup)
         else:
             bot.send_message(chat_id=chatid, text=messaggio, disable_web_page_preview=disable_webpage_preview)
     except Unauthorized:  # user blocked the bot

--- a/ChaturbateBot.py
+++ b/ChaturbateBot.py
@@ -44,7 +44,6 @@ def send_message(chatid: str, messaggio: str, bot: updater.bot, html: bool = Fal
     """
     Sends a message to a telegram user and sends "typing" action
 
-    :param notification: Enable or disable notifications of the message
     :param markup: The reply_markup to use when sending the message
     :param chatid: The chatid of the user who will receive the message
     :param messaggio: The message who the user will receive

--- a/ChaturbateBot.py
+++ b/ChaturbateBot.py
@@ -290,16 +290,18 @@ settings_menu_keyboard = [[InlineKeyboardButton("Link preview", callback_data='l
 def settings(update, CallbackContext):
     global bot
     global settings_menu_keyboard
+    chatid = update.effective_chat.id
 
     message_markup = InlineKeyboardMarkup(settings_menu_keyboard)
 
-    #Todo show actual settings values in message
+    Link_preview_setting = Preferences.get_user_link_preview_preference(chatid)
+    Notification_setting = Preferences.get_user_notifications_preference(chatid)
+    settings_message= f"Here are your settings:\nLink preview: <b>{Link_preview_setting}</b>\nNotifications: <b>{Notification_setting}</b>"
 
     if update.callback_query:
-        update.callback_query.edit_message_text(text='Here are your settings:',reply_markup=message_markup)
+        update.callback_query.edit_message_text(text=settings_message,reply_markup=message_markup,parse_mode=telegram.ParseMode.HTML)
     else:
-        chatid = update.message.chat.id
-        send_message(chatid,'Here are your settings:',bot,markup=message_markup)
+        send_message(chatid,settings_message,bot,markup=message_markup,html=True)
 
 def link_preview_callback(update, CallbackContext):
     query = update.callback_query

--- a/ChaturbateBot.py
+++ b/ChaturbateBot.py
@@ -40,10 +40,11 @@ logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s
 
 
 
-def send_message(chatid: str, messaggio: str, bot: updater.bot, html: bool = False, markup=None) -> None:
+def send_message(chatid: str, messaggio: str, bot: updater.bot, html: bool = False, markup=None, notification: bool = True) -> None:
     """
     Sends a message to a telegram user and sends "typing" action
 
+    :param notification: Enable or disable notifications of the message
     :param markup: The reply_markup to use when sending the message
     :param chatid: The chatid of the user who will receive the message
     :param messaggio: The message who the user will receive
@@ -54,19 +55,21 @@ def send_message(chatid: str, messaggio: str, bot: updater.bot, html: bool = Fal
     disable_webpage_preview = not Preferences.get_user_link_preview_preference(
         chatid)  # the setting is opposite of preference
 
+    notification = not notification # the setting is opposite of preference
+
     try:
         bot.send_chat_action(chat_id=chatid, action="typing")
         if html and markup!=None:
             bot.send_message(chat_id=chatid, text=messaggio,
-                             parse_mode=telegram.ParseMode.HTML, disable_web_page_preview=disable_webpage_preview,reply_markup=markup)
+                             parse_mode=telegram.ParseMode.HTML, disable_web_page_preview=disable_webpage_preview,reply_markup=markup,disable_notification=notification)
         elif html:
             bot.send_message(chat_id=chatid, text=messaggio,
-                             parse_mode=telegram.ParseMode.HTML, disable_web_page_preview=disable_webpage_preview)
+                             parse_mode=telegram.ParseMode.HTML, disable_web_page_preview=disable_webpage_preview,disable_notification=notification)
         elif markup!=None:
             bot.send_message(chat_id=chatid, text=messaggio,disable_web_page_preview=disable_webpage_preview,
-                             reply_markup=markup)
+                             reply_markup=markup,disable_notification=notification)
         else:
-            bot.send_message(chat_id=chatid, text=messaggio, disable_web_page_preview=disable_webpage_preview)
+            bot.send_message(chat_id=chatid, text=messaggio, disable_web_page_preview=disable_webpage_preview,disable_notification=notification)
     except Unauthorized:  # user blocked the bot
         if auto_remove == True:
             logging.info(f"{chatid} blocked the bot, he's been removed from the database")

--- a/modules/Preferences.py
+++ b/modules/Preferences.py
@@ -70,7 +70,7 @@ def get_user_link_preview_preference(chatid: str) -> bool:
         return True
 
 
-def update_notifications_preference(chatid: str, value: bool) -> None:
+def update_notifications_sound_preference(chatid: str, value: bool) -> None:
     """
     Update the notifications preference of the user
 
@@ -82,10 +82,10 @@ def update_notifications_preference(chatid: str, value: bool) -> None:
     else:
         value = 0
 
-    Utils.exec_query(f"UPDATE PREFERENCES SET NOTIFICATIONS='{value}' WHERE CHAT_ID='{chatid}'")
+    Utils.exec_query(f"UPDATE PREFERENCES SET NOTIFICATIONS_SOUND='{value}' WHERE CHAT_ID='{chatid}'")
 
 
-def get_user_notifications_preference(chatid: str) -> bool:
+def get_user_notifications_sound_preference(chatid: str) -> bool:
     """
     Retrieve the notifications preference of the user
 
@@ -95,7 +95,7 @@ def get_user_notifications_preference(chatid: str) -> bool:
     if not user_has_preferences(chatid):
         add_user_to_preferences(chatid)
 
-    results = Utils.retrieve_query_results(f"SELECT NOTIFICATIONS FROM PREFERENCES WHERE CHAT_ID={chatid}")
+    results = Utils.retrieve_query_results(f"SELECT NOTIFICATIONS_SOUND FROM PREFERENCES WHERE CHAT_ID={chatid}")
     if results[0][0] == 0:
         return False
     else:

--- a/modules/Preferences.py
+++ b/modules/Preferences.py
@@ -11,7 +11,7 @@ def user_has_preferences(chatid: str) -> bool:
     :param chatid: The chatid of the user who will be tested
     :return: True if it exists, False if it doesn't exist
     """
-    results = Utils.retrieve_query_results(f"SELECT LINK_PREVIEW FROM PREFERENCES WHERE CHAT_ID={chatid}")
+    results = Utils.retrieve_query_results(f"SELECT * FROM PREFERENCES WHERE CHAT_ID={chatid}")
     if not results:
         return False
     else:
@@ -24,7 +24,7 @@ def add_user_to_preferences(chatid: str) -> None:
 
     :param chatid: The chatid of the user who will be tested
     """
-    Utils.exec_query(f"INSERT INTO PREFERENCES VALUES ('{chatid}', '1')")
+    Utils.exec_query(f"INSERT INTO PREFERENCES VALUES ('{chatid}', '1', '1')")
     logging.info(f'{chatid} has been added to preferences')
 
 
@@ -64,6 +64,38 @@ def get_user_link_preview_preference(chatid: str) -> bool:
         add_user_to_preferences(chatid)
 
     results = Utils.retrieve_query_results(f"SELECT LINK_PREVIEW FROM PREFERENCES WHERE CHAT_ID={chatid}")
+    if results[0][0] == 0:
+        return False
+    else:
+        return True
+
+
+def update_notifications_preference(chatid: str, value: bool) -> None:
+    """
+    Update the notifications preference of the user
+
+    :param chatid: The chatid of the user who will be tested
+    :param value: The boolean value that will be converted to int and inserted in the table
+    """
+    if value:
+        value = 1
+    else:
+        value = 0
+
+    Utils.exec_query(f"UPDATE PREFERENCES SET NOTIFICATIONS='{value}' WHERE CHAT_ID='{chatid}'")
+
+
+def get_user_notifications_preference(chatid: str) -> bool:
+    """
+    Retrieve the notifications preference of the user
+
+    :param chatid: The chatid of the user who will be tested
+    :return: The boolean value of the preference
+    """
+    if not user_has_preferences(chatid):
+        add_user_to_preferences(chatid)
+
+    results = Utils.retrieve_query_results(f"SELECT NOTIFICATIONS FROM PREFERENCES WHERE CHAT_ID={chatid}")
     if results[0][0] == 0:
         return False
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-python-telegram-bot
+python-telegram-bot>=12.0.0b1
 beautifulsoup4
 requests_futures
 pillow


### PR DESCRIPTION
Implemented settings command with callbacks
Removed link_preview command and moved the setting into /settings
Implemented notifications_sound setting
Cleaned up handlers_code
Note: the v12 api is not retro-compatibile with old code, thus it had to be modified